### PR TITLE
Update example_config.json structure due to parsing error

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -72,8 +72,8 @@
                     }
                 }
             ],
-            "areas": {
-                "area": {
+            "areas": [
+                {
                     "name": "Area1",
                     "bottom_left": {
                         "x": "8000",
@@ -84,7 +84,7 @@
                         "y": "9000"
                     }
                 }
-            },
+            ],
             "zones": [
                 {
                     "name": "Zone1",


### PR DESCRIPTION
Traceback (most recent call last):
  File "main.py", line 82, in <module>
    main()
  File "main.py", line 49, in main
    zones = parser.parse_zones()
  File "json_parser.py", line 145, in parse_zones
    areas = self.parse_areas()
  File "json_parser.py", line 135, in parse_areas
    return self.__parse_rectangle('areas', Area)
  File "json_parser.py", line 102, in __parse_rectangle
    name = element['name']
TypeError: string indices must be integers